### PR TITLE
Use InstallSh strategy if not configured to use cached.

### DIFF
--- a/lib/chef/provisioning/vsphere_driver/driver.rb
+++ b/lib/chef/provisioning/vsphere_driver/driver.rb
@@ -757,8 +757,12 @@ module ChefProvisioningVsphere
         Chef::Provisioning::ConvergenceStrategy::InstallMsi.new(
           mopts, config
         )
-      else
+      elsif machine_options[:cached_installer] == true
         Chef::Provisioning::ConvergenceStrategy::InstallCached.new(
+          mops, config
+        )
+      else
+        Chef::Provisioning::ConvergenceStrategy::InstallSh.new(
           mopts, config
         )
       end


### PR DESCRIPTION
Copying the logic across from the AWS provisioner.